### PR TITLE
Fixed authentication, added examples.

### DIFF
--- a/Dump.py
+++ b/Dump.py
@@ -1,0 +1,49 @@
+import RPi.GPIO as GPIO
+import MFRC522
+import signal
+
+continue_reading = True
+
+# Capture SIGINT for cleanup when the script is aborted
+def end_read(signal,frame):
+    global continue_reading
+    print "Ctrl+C captured, ending read."
+    continue_reading = False
+    GPIO.cleanup()
+
+# Hook the SIGINT
+signal.signal(signal.SIGINT, end_read)
+
+# Create an object of the class MFRC522
+MIFAREReader = MFRC522.MFRC522()
+
+# This loop keeps checking for chips. If one is near it will get the UID and authenticate
+while continue_reading:
+    
+    # Scan for cards    
+    (status,TagType) = MIFAREReader.MFRC522_Request(MIFAREReader.PICC_REQIDL)
+
+    # If a card is found
+    if status == MIFAREReader.MI_OK:
+        print "Card detected"
+    
+    # Get the UID of the card
+    (status,uid) = MIFAREReader.MFRC522_Anticoll()
+
+    # If we have the UID, continue
+    if status == MIFAREReader.MI_OK:
+
+        # Print UID
+        print "Card read UID: "+str(uid[0])+","+str(uid[1])+","+str(uid[2])+","+str(uid[3])
+    
+        # This is the default key for authentication
+        key = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
+        
+        # Select the scanned tag
+        MIFAREReader.MFRC522_SelectTag(uid)
+
+        # Dump the data
+        MIFAREReader.MFRC522_DumpClassic1K(key, uid)
+
+        # Stop
+        MIFAREReader.MFRC522_StopCrypto1()

--- a/README.md
+++ b/README.md
@@ -5,21 +5,26 @@ A small class to interface with the NFC reader Module MFRC522 on the Raspberry P
 
 This is a Python port of the example code for the NFC module MF522-AN.
 
-Pre Requisites
-==============
-
-You will need to install SPI-Py from lthiery from the following address:
-
+##Requirements
+This code requires you to have SPI-Py installed from the following repository:
 https://github.com/lthiery/SPI-Py
 
-More Info
-==============
+##Examples
+This repository includes a couple of examples showing how to read, write, and dump data from a chip. They are thoroughly commented, and should be easy to understand.
 
-For more information visit: http://fuenteabierta.teubi.co/
+## Pins
+You can use [this](http://i.imgur.com/y7Fnvhq.png) image for reference.
 
-Usage
-==============
+| Name | Pin # | Pin name   |
+|------|-------|------------|
+| SDA  | 24    | GPIO8      |
+| SCK  | 23    | GPIO11     |
+| MOSI | 19    | GPIO10     |
+| MISO | 21    | GPIO9      |
+| IRQ  | None  | None       |
+| GND  | Any   | Any Ground |
+| RST  | 22    | GPIO25     |
+| 3.3V | 1     | 3V3        |
 
-Just run the following command:
-
-sudo python MFRC522.py
+##Usage
+Import the class by importing MFRC522 in the top of your script. For more info see the examples.

--- a/Read.py
+++ b/Read.py
@@ -1,0 +1,56 @@
+import RPi.GPIO as GPIO
+import MFRC522
+import signal
+
+continue_reading = True
+
+# Capture SIGINT for cleanup when the script is aborted
+def end_read(signal,frame):
+    global continue_reading
+    print "Ctrl+C captured, ending read."
+    continue_reading = False
+    GPIO.cleanup()
+
+# Hook the SIGINT
+signal.signal(signal.SIGINT, end_read)
+
+# Create an object of the class MFRC522
+MIFAREReader = MFRC522.MFRC522()
+
+# This loop keeps checking for chips. If one is near it will get the UID and authenticate
+while continue_reading:
+    
+    # Scan for cards    
+    (status,TagType) = MIFAREReader.MFRC522_Request(MIFAREReader.PICC_REQIDL)
+
+    # If a card is found
+    if status == MIFAREReader.MI_OK:
+        print "Card detected"
+    
+    # Get the UID of the card
+    (status,uid) = MIFAREReader.MFRC522_Anticoll()
+
+    # If we have the UID, continue
+    if status == MIFAREReader.MI_OK:
+
+        # Print UID
+        print "Card read UID: "+str(uid[0])+","+str(uid[1])+","+str(uid[2])+","+str(uid[3])
+    
+        # This is the default key for authentication
+        key = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
+        
+        # Select the scanned tag
+        MIFAREReader.MFRC522_SelectTag(uid)
+
+        # Authenticate
+        status = MIFAREReader.MFRC522_Auth(MIFAREReader.PICC_AUTHENT1A, 8, key, uid)
+
+        # Check if authenticated
+        if status == MIFAREReader.MI_OK:
+            MIFAREReader.MFRC522_Read(8)
+            MIFAREReader.MFRC522_StopCrypto1()
+        else:
+            print "Authentication error"
+
+        # Make sure to stop scanning for cards
+        continue_reading = false

--- a/Write.py
+++ b/Write.py
@@ -1,0 +1,94 @@
+import RPi.GPIO as GPIO
+import MFRC522
+import signal
+
+continue_reading = True
+
+# Capture SIGINT for cleanup when the script is aborted
+def end_read(signal,frame):
+    global continue_reading
+    print "Ctrl+C captured, ending read."
+    continue_reading = False
+    GPIO.cleanup()
+
+# Hook the SIGINT
+signal.signal(signal.SIGINT, end_read)
+
+# Create an object of the class MFRC522
+MIFAREReader = MFRC522.MFRC522()
+
+# This loop keeps checking for chips. If one is near it will get the UID and authenticate
+while continue_reading:
+    
+    # Scan for cards    
+    (status,TagType) = MIFAREReader.MFRC522_Request(MIFAREReader.PICC_REQIDL)
+
+    # If a card is found
+    if status == MIFAREReader.MI_OK:
+        print "Card detected"
+    
+    # Get the UID of the card
+    (status,uid) = MIFAREReader.MFRC522_Anticoll()
+
+    # If we have the UID, continue
+    if status == MIFAREReader.MI_OK:
+
+        # Print UID
+        print "Card read UID: "+str(uid[0])+","+str(uid[1])+","+str(uid[2])+","+str(uid[3])
+    
+        # This is the default key for authentication
+        key = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
+        
+        # Select the scanned tag
+        MIFAREReader.MFRC522_SelectTag(uid)
+
+        # Authenticate
+        status = MIFAREReader.MFRC522_Auth(MIFAREReader.PICC_AUTHENT1A, 8, key, uid)
+        print "\n"
+
+        # Check if authenticated
+        if status == MIFAREReader.MI_OK:
+
+            # Variable for the data to write
+            data = []
+
+            # Fill the data with 0xFF
+            for x in range(0,16):
+                data.append(0xFF)
+
+            print "Sector 8 looked like this:"
+            # Read block 8
+            MIFAREReader.MFRC522_Read(8)
+            print "\n"
+
+            print "Sector 8 will now be filled with 0xFF:"
+            # Write the data
+            MIFAREReader.MFRC522_Write(8, data)
+            print "\n"
+
+            print "It now looks like this:"
+            # Check to see if it was written
+            MIFAREReader.MFRC522_Read(8)
+            print "\n"
+
+            data = []
+            # Fill the data with 0x00
+            for x in range(0,16):
+                data.append(0x00)
+
+            print "Now we fill it with 0x00:"
+            MIFAREReader.MFRC522_Write(8, data)
+            print "\n"
+
+            print "It is now empty:"
+            # Check to see if it was written
+            MIFAREReader.MFRC522_Read(8)
+            print "\n"
+
+            # Stop
+            MIFAREReader.MFRC522_StopCrypto1()
+
+            # Make sure to stop reading for cards
+            continue_reading = False
+        else:
+            print "Authentication error"


### PR DESCRIPTION
Authentication has been fixed and is now working. The issue was with the UID, as we only want the first 4 bytes of the backdate (the UID) appended when authenticating.

I've also removed the code in the bottom of the file MFRC522.py, as it should be easy to import it to whatever project you're doing. Instead I've added some proper examples showing how to read, write, and dump data. 

Some comments have also been added here and there for better documenting what is happening. A function called StopCrypto1() has also been added for stopping authentication so that you can scan another card. 
