### PR TITLE
support for newer SPI-Py

### DIFF
--- a/MFRC522.py
+++ b/MFRC522.py
@@ -128,7 +128,7 @@ class MFRC522:
   serNum = []
   
   def __init__(self, dev='/dev/spidev0.0', spd=1000000):
-    spi.openSPI(device=dev,speed=spd)
+    self.dev_dictionary = spi.openSPI(device=dev,speed=spd)
     GPIO.setmode(GPIO.BOARD)
     GPIO.setup(self.NRSTPD, GPIO.OUT)
     GPIO.output(self.NRSTPD, 1)
@@ -138,10 +138,10 @@ class MFRC522:
     self.Write_MFRC522(self.CommandReg, self.PCD_RESETPHASE)
   
   def Write_MFRC522(self, addr, val):
-    spi.transfer(((addr<<1)&0x7E,val))
+    spi.transfer(self.dev_dictionary, ((addr<<1)&0x7E,val))
   
   def Read_MFRC522(self, addr):
-    val = spi.transfer((((addr<<1)&0x7E) | 0x80,0))
+    val = spi.transfer(self.dev_dictionary, (((addr<<1)&0x7E) | 0x80,0))
     return val[1]
   
   def SetBitMask(self, reg, mask):


### PR DESCRIPTION
Based on these [instructions](https://github.com/lthiery/SPI-Py#instructions).

This fixes https://github.com/mxgxw/MFRC522-python/issues/69